### PR TITLE
Syntax Fixes and Resturcturing Python3 Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# AquaLung UI

--- a/aqualung_ui.py
+++ b/aqualung_ui.py
@@ -1,52 +1,56 @@
 import sys
-from PyQt5 import QtCore, QtGui, QtWidgets
+
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
+
 from mainwindow import UIMainWindow
 from settings import AqualungSettings
 
 
-class AqualungUi(QtWidgets.QMainWindow, UIMainWindow):
+class AqualungUI(QtWidgets.QMainWindow, UIMainWindow):
 
     def __init__(self, *args, obj=None, **kwargs):
-        super(AqualungUi, self).__init__(*args, **kwargs)
+        super(AqualungUI, self).__init__(*args, **kwargs)
         self.setup_ui(self)
         self.settings = AqualungSettings()
         self.connect()
 
     def connect(self):
-        self.mode_button.clicked.connect(self.mode_changed)
-        self.tv_slider.valueChanged.connect(self.tv_changed)
-        self.ie_slider.valueChanged.connect(self.ie_changed)
-        self.fio2_slider.valueChanged.connect(self.fio2_changed)
-        self.resp_rate_slider.valueChanged.connect(self.resp_rate_changed)
+        self.widgets.mode["button"].clicked.connect(self.mode_changed)
+        self.widgets.tv["slider"].valueChanged.connect(self.tv_changed)
+        self.widgets.ie["slider"].valueChanged.connect(self.ie_changed)
+        self.widgets.fio2["slider"].valueChanged.connect(self.fio2_changed)
+        self.widgets.resp_rate["slider"].valueChanged.connect(self.resp_rate_changed)
 
     def mode_changed(self):
-        self.settings.mode = self.mode_button.isChecked()  # mode = True -> AC, False -> SIMV
+        self.settings.mode = self.widgets.mode["button"].isChecked()  # mode = True -> AC, False -> SIMV
         if self.settings.mode:
-            self.mode_button.setText("AC")
+            self.widgets.mode["button"].setText("AC")
         else:
-            self.mode_button.setText("SIMV")
+            self.widgets.mode["button"].setText("SIMV")
 
     def tv_changed(self):
-        self.settings.tv = self.tv_slider.value()
-        self.tv_lcd.display(int(self.settings.tv))
+        self.settings.tv = self.widgets.tv["slider"].value()
+        self.widgets.tv["lcd"].display(int(self.settings.tv))
 
     def ie_changed(self):
-        self.settings.ie = self.ie_slider.value()
-        self.ie_lcd.display(int(self.settings.ie))
+        self.settings.ie = self.widgets.ie["slider"].value()
+        self.widgets.ie["lcd"].display(int(self.settings.ie))
 
     def fio2_changed(self):
-        self.settings.fio2 = self.fio2_slider.value()
-        self.fio2_lcd.display(int(self.settings.fio2))
+        self.settings.fio2 = self.widgets.fio2["slider"].value()
+        self.widgets.fio2["lcd"].display(int(self.settings.fio2))
 
     def resp_rate_changed(self):
-        self.settings.resp_rate = self.resp_rate_slider.value()
-        self.resp_rate_lcd.display(int(self.settings.resp_rate))
+        self.settings.resp_rate = self.widgets.resp_rate["slider"].value()
+        self.widgets.resp_rate["lcd"].display(int(self.settings.resp_rate))
 
 
 def main():
     app = QtWidgets.QApplication(sys.argv)
 
-    window = AqualungUi()
+    window = AqualungUI()
     screen_size = app.desktop().screenGeometry() #get the current screensize as a PyQt5 QRect
     window.resize(screen_size.width(), screen_size.height()) #resize window to screensize
     window.show()

--- a/aqualung_ui.py
+++ b/aqualung_ui.py
@@ -1,13 +1,14 @@
 import sys
 from PyQt5 import QtCore, QtGui, QtWidgets
-from mainwindow import Ui_MainWindow
+from mainwindow import UIMainWindow
 from settings import AqualungSettings
 
-class AqualungUi(QtWidgets.QMainWindow, Ui_MainWindow):
+
+class AqualungUi(QtWidgets.QMainWindow, UIMainWindow):
 
     def __init__(self, *args, obj=None, **kwargs):
         super(AqualungUi, self).__init__(*args, **kwargs)
-        self.setupUi(self)
+        self.setup_ui(self)
         self.settings = AqualungSettings()
         self.connect()
 
@@ -41,12 +42,15 @@ class AqualungUi(QtWidgets.QMainWindow, Ui_MainWindow):
         self.settings.resp_rate = self.resp_rate_slider.value()
         self.resp_rate_lcd.display(int(self.settings.resp_rate))
 
-app = QtWidgets.QApplication(sys.argv)
 
-window = AqualungUi()
-screen_size = app.desktop().screenGeometry() #get the current screensize as a PyQt5 QRect
-window.resize(screen_size.width(), screen_size.height()) #resize window to screensize
-window.show()
-app.exec()
+def main():
+    app = QtWidgets.QApplication(sys.argv)
 
+    window = AqualungUi()
+    screen_size = app.desktop().screenGeometry() #get the current screensize as a PyQt5 QRect
+    window.resize(screen_size.width(), screen_size.height()) #resize window to screensize
+    window.show()
+    app.exec()
 
+if __name__ == "__main__":
+    main()

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -10,8 +10,8 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
-    def setupUi(self, MainWindow):
+class UIMainWindow():
+    def setup_ui(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(1200, 855)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
@@ -128,10 +128,10 @@ class Ui_MainWindow(object):
         self.statusbar.setObjectName("statusbar")
         MainWindow.setStatusBar(self.statusbar)
 
-        self.retranslateUi(MainWindow)
+        self.retranslate_ui(MainWindow)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
-    def retranslateUi(self, MainWindow):
+    def retranslate_ui(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "MainWindow"))
         self.plateau_press_label.setText(_translate("MainWindow", "Plateau Pressure"))

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -5,141 +5,225 @@
 # Created by: PyQt5 UI code generator 5.14.1
 #
 # WARNING! All changes made in this file will be lost!
+from typing import Dict
 
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from widgets import AquaWidgets
 
 
 class UIMainWindow():
-    def setup_ui(self, MainWindow):
-        MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(1200, 855)
-        self.centralwidget = QtWidgets.QWidget(MainWindow)
-        self.centralwidget.setObjectName("centralwidget")
-        self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
-        self.gridLayout.setObjectName("gridLayout")
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem, 9, 1, 1, 1)
-        spacerItem1 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem1, 11, 1, 1, 1)
-        self.fio2_slider = QtWidgets.QSlider(self.centralwidget)
-        self.fio2_slider.setOrientation(QtCore.Qt.Horizontal)
-        self.fio2_slider.setObjectName("fio2_slider")
-        self.gridLayout.addWidget(self.fio2_slider, 13, 3, 1, 1)
-        spacerItem2 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem2, 1, 1, 1, 1)
-        spacerItem3 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem3, 8, 2, 1, 1)
-        spacerItem4 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem4, 15, 1, 1, 1)
-        spacerItem5 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem5, 3, 1, 1, 1)
-        spacerItem6 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem6, 13, 1, 1, 1)
-        spacerItem7 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem7, 7, 1, 1, 1)
-        self.plateau_press_label = QtWidgets.QLabel(self.centralwidget)
-        self.plateau_press_label.setObjectName("plateau_press_label")
-        self.gridLayout.addWidget(self.plateau_press_label, 7, 0, 1, 1)
-        self.tv_label = QtWidgets.QLabel(self.centralwidget)
-        self.tv_label.setObjectName("tv_label")
-        self.gridLayout.addWidget(self.tv_label, 9, 0, 1, 1)
-        spacerItem8 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem8, 15, 4, 1, 1)
-        self.ie_label = QtWidgets.QLabel(self.centralwidget)
-        self.ie_label.setObjectName("ie_label")
-        self.gridLayout.addWidget(self.ie_label, 11, 0, 1, 1)
-        self.ie_slider = QtWidgets.QSlider(self.centralwidget)
-        self.ie_slider.setOrientation(QtCore.Qt.Horizontal)
-        self.ie_slider.setObjectName("ie_slider")
-        self.gridLayout.addWidget(self.ie_slider, 11, 3, 1, 1)
-        self.resp_rate_label = QtWidgets.QLabel(self.centralwidget)
-        self.resp_rate_label.setObjectName("resp_rate_label")
-        self.gridLayout.addWidget(self.resp_rate_label, 15, 0, 1, 1)
-        self.resp_rate_slider = QtWidgets.QSlider(self.centralwidget)
-        self.resp_rate_slider.setOrientation(QtCore.Qt.Horizontal)
-        self.resp_rate_slider.setObjectName("resp_rate_slider")
-        self.gridLayout.addWidget(self.resp_rate_slider, 15, 3, 1, 1)
-        spacerItem9 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem9, 6, 2, 1, 1)
-        self.resp_rate_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.resp_rate_lcd.setObjectName("resp_rate_lcd")
-        self.gridLayout.addWidget(self.resp_rate_lcd, 15, 2, 1, 1)
-        self.tv_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.tv_lcd.setObjectName("tv_lcd")
-        self.gridLayout.addWidget(self.tv_lcd, 9, 2, 1, 1)
-        spacerItem10 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem10, 0, 2, 1, 1)
-        spacerItem11 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem11, 12, 2, 1, 1)
-        self.ie_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.ie_lcd.setObjectName("ie_lcd")
-        self.gridLayout.addWidget(self.ie_lcd, 11, 2, 1, 1)
-        spacerItem12 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem12, 10, 2, 1, 1)
-        spacerItem13 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem13, 4, 2, 1, 1)
-        spacerItem14 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout.addItem(spacerItem14, 5, 1, 1, 1)
-        self.plateau_press_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.plateau_press_lcd.setObjectName("plateau_press_lcd")
-        self.gridLayout.addWidget(self.plateau_press_lcd, 7, 2, 1, 1)
-        self.fio2_label = QtWidgets.QLabel(self.centralwidget)
-        self.fio2_label.setObjectName("fio2_label")
-        self.gridLayout.addWidget(self.fio2_label, 13, 0, 1, 1)
-        spacerItem15 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem15, 2, 2, 1, 1)
-        self.peep_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.peep_lcd.setObjectName("peep_lcd")
-        self.gridLayout.addWidget(self.peep_lcd, 3, 2, 1, 1)
-        self.fio2_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.fio2_lcd.setObjectName("fio2_lcd")
-        self.gridLayout.addWidget(self.fio2_lcd, 13, 2, 1, 1)
-        self.mode_button = QtWidgets.QPushButton(self.centralwidget)
-        self.mode_button.setCheckable(True)
-        self.mode_button.setObjectName("mode_button")
-        self.gridLayout.addWidget(self.mode_button, 1, 2, 1, 1)
-        self.mode_label = QtWidgets.QLabel(self.centralwidget)
-        self.mode_label.setObjectName("mode_label")
-        self.gridLayout.addWidget(self.mode_label, 1, 0, 1, 1)
-        self.peak_press_lcd = QtWidgets.QLCDNumber(self.centralwidget)
-        self.peak_press_lcd.setObjectName("peak_press_lcd")
-        self.gridLayout.addWidget(self.peak_press_lcd, 5, 2, 1, 1)
-        self.peak_press_label = QtWidgets.QLabel(self.centralwidget)
-        self.peak_press_label.setObjectName("peak_press_label")
-        self.gridLayout.addWidget(self.peak_press_label, 5, 0, 1, 1)
-        self.peep_label = QtWidgets.QLabel(self.centralwidget)
-        self.peep_label.setObjectName("peep_label")
-        self.gridLayout.addWidget(self.peep_label, 3, 0, 1, 1)
-        self.tv_slider = QtWidgets.QSlider(self.centralwidget)
-        self.tv_slider.setOrientation(QtCore.Qt.Horizontal)
-        self.tv_slider.setObjectName("tv_slider")
-        self.gridLayout.addWidget(self.tv_slider, 9, 3, 1, 1)
-        spacerItem16 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem16, 14, 2, 1, 1)
-        spacerItem17 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem17, 16, 2, 1, 1)
-        MainWindow.setCentralWidget(self.centralwidget)
-        self.menubar = QtWidgets.QMenuBar(MainWindow)
+    def __init__(self) -> None:
+        self.central_widget = None
+        self.grid_layout = None
+        self.widgets = AquaWidgets()
+        self.menubar = None
+        self.statusbar = None
+
+    def setup_ui(self, main_window) -> None:
+        main_window.setObjectName("MainWindow")
+        main_window.resize(1200, 855)
+        spacer_item = {
+            "0": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "1": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "2": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "3": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "4": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "5": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "6": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "7": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "8": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "9": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "10": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "11": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "12": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "13": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "14": QtWidgets.QSpacerItem(
+                40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum),
+            "15": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "16": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+            "17": QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
+        }
+
+        self.central_widget = QtWidgets.QWidget(main_window)
+        self.central_widget.setObjectName("centralwidget")
+        self.grid_layout = QtWidgets.QGridLayout(self.central_widget)
+        self.grid_layout.setObjectName("gridLayout")
+        self.grid_layout.addItem(spacer_item["0"], 9, 1, 1, 1)
+        self.grid_layout.addItem(spacer_item["1"], 11, 1, 1, 1)
+
+        # Set Widgets
+        self._set_mode_widget()
+        self._set_peep_widget()
+        self._set_peak_widget()
+        self._set_plateau_pressue_widget()
+        self._set_tidal_volume_widget(spacer_item)
+        self._set_ie_ratio_widget(spacer_item)
+        self._set_fio2_widget(spacer_item)
+        self._set_respitory_rate_widget(spacer_item)
+
+        # Set Central Widget
+        main_window.setCentralWidget(self.central_widget)
+
+        # Set Menu and Status Bar
+        self.menubar = QtWidgets.QMenuBar(main_window)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 1200, 22))
         self.menubar.setObjectName("menubar")
-        MainWindow.setMenuBar(self.menubar)
-        self.statusbar = QtWidgets.QStatusBar(MainWindow)
+        main_window.setMenuBar(self.menubar)
+        self.statusbar = QtWidgets.QStatusBar(main_window)
         self.statusbar.setObjectName("statusbar")
-        MainWindow.setStatusBar(self.statusbar)
+        main_window.setStatusBar(self.statusbar)
 
-        self.retranslate_ui(MainWindow)
-        QtCore.QMetaObject.connectSlotsByName(MainWindow)
+        self.retranslate_ui(main_window)
+        QtCore.QMetaObject.connectSlotsByName(main_window)
 
-    def retranslate_ui(self, MainWindow):
+    def _set_mode_widget(self) -> None:
+        """ Set Mode Label and Button """
+        self.widgets.mode["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.mode["label"].setObjectName("mode_label")
+        self.grid_layout.addWidget(self.widgets.mode["label"], 1, 0, 1, 1)
+
+        self.widgets.mode["button"] = QtWidgets.QPushButton(self.central_widget)
+        self.widgets.mode["button"].setCheckable(True)
+        self.widgets.mode["button"].setObjectName("mode_button")
+        self.grid_layout.addWidget(self.widgets.mode["button"], 1, 2, 1, 1)
+
+    def _set_peep_widget(self) -> None:
+        """ Set PEEP Label and LCD """ 
+        self.widgets.peep["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.peep["label"].setObjectName("peep_label")
+        self.grid_layout.addWidget(self.widgets.peep["label"], 3, 0, 1, 1)
+
+        self.widgets.peep["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.peep["lcd"].setObjectName("peep_lcd")
+        self.grid_layout.addWidget(self.widgets.peep["lcd"], 3, 2, 1, 1)
+
+    def _set_peak_widget(self) -> None:
+        """ Peak Press Label and LCD """
+        self.widgets.peak_press["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.peak_press["label"].setObjectName("peak_press_label")
+        self.grid_layout.addWidget(self.widgets.peak_press["label"], 5, 0, 1, 1)
+
+        self.widgets.peak_press["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.peak_press["lcd"].setObjectName("peak_press_lcd")
+        self.grid_layout.addWidget(self.widgets.peak_press["lcd"], 5, 2, 1, 1)
+
+    def _set_plateau_pressue_widget(self) -> None:
+        # Plateau Press Label and LCD
+        self.widgets.plateau_press["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.plateau_press["label"].setObjectName("plateau_press_label")
+        self.grid_layout.addWidget(self.widgets.plateau_press["label"], 7, 0, 1, 1)
+
+        self.widgets.plateau_press["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.plateau_press["lcd"].setObjectName("plateau_press_lcd")
+        self.grid_layout.addWidget(self.widgets.plateau_press["lcd"], 7, 2, 1, 1)
+
+    def _set_tidal_volume_widget(self, spacer_item: Dict) -> None:
+        """ Set Tidal Volume Label, LCD, SLIDER """
+        self.widgets.tv["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.tv["label"].setObjectName("tv_label")
+        self.grid_layout.addWidget(self.widgets.tv["label"], 9, 0, 1, 1)
+        self.grid_layout.addItem(spacer_item["8"], 15, 4, 1, 1)
+
+        self.widgets.tv["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.tv["lcd"].setObjectName("tv_lcd")
+        self.grid_layout.addWidget(self.widgets.tv["lcd"], 9, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["10"], 0, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["11"], 12, 2, 1, 1)
+
+        self.widgets.tv["slider"] = QtWidgets.QSlider(self.central_widget)
+        self.widgets.tv["slider"].setOrientation(QtCore.Qt.Horizontal)
+        self.widgets.tv["slider"].setObjectName("tv_slider")
+        self.grid_layout.addWidget(self.widgets.tv["slider"], 9, 3, 1, 1)
+        self.grid_layout.addItem(spacer_item["16"], 14, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["17"], 16, 2, 1, 1)
+
+    def _set_ie_ratio_widget(self, spacer_item: Dict) -> None:
+        """ Set IE ratio Label, LCD, and Slider """
+        self.widgets.ie["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.ie["label"].setObjectName("ie_label")
+        self.grid_layout.addWidget(self.widgets.ie["label"], 11, 0, 1, 1)
+
+        self.widgets.ie["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.ie["lcd"].setObjectName("ie_lcd")
+        self.grid_layout.addWidget(self.widgets.ie["lcd"], 11, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["12"], 10, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["13"], 4, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["14"], 5, 1, 1, 1)
+
+        self.widgets.ie["slider"] = QtWidgets.QSlider(self.central_widget)
+        self.widgets.ie["slider"].setOrientation(QtCore.Qt.Horizontal)
+        self.widgets.ie["slider"].setObjectName("ie_slider")
+        self.grid_layout.addWidget(self.widgets.ie["slider"], 11, 3, 1, 1)
+
+    def _set_fio2_widget(self, spacer_item: Dict) -> None:
+        """ FiO2 Label, LCD, and Slider """
+        self.widgets.fio2["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.fio2["label"].setObjectName("fio2_label")
+        self.grid_layout.addWidget(self.widgets.fio2["label"], 13, 0, 1, 1)
+        self.grid_layout.addItem(spacer_item["15"], 2, 2, 1, 1)
+
+        self.widgets.fio2["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.fio2["lcd"].setObjectName("fio2_lcd")
+        self.grid_layout.addWidget(self.widgets.fio2["lcd"], 13, 2, 1, 1)
+
+        self.widgets.fio2["slider"] = QtWidgets.QSlider(self.central_widget)
+        self.widgets.fio2["slider"].setOrientation(QtCore.Qt.Horizontal)
+        self.widgets.fio2["slider"].setObjectName("fio2_slider")
+        self.grid_layout.addWidget(self.widgets.fio2["slider"], 13, 3, 1, 1)
+        self.grid_layout.addItem(spacer_item["2"], 1, 1, 1, 1)
+        self.grid_layout.addItem(spacer_item["3"], 8, 2, 1, 1)
+        self.grid_layout.addItem(spacer_item["4"], 15, 1, 1, 1)
+        self.grid_layout.addItem(spacer_item["5"], 3, 1, 1, 1)
+        self.grid_layout.addItem(spacer_item["6"], 13, 1, 1, 1)
+        self.grid_layout.addItem(spacer_item["7"], 7, 1, 1, 1)
+
+    def _set_respitory_rate_widget(self, spacer_item: Dict) -> None:
+        # Respitory Rate Label, LCD, and Slider
+        self.widgets.resp_rate["label"] = QtWidgets.QLabel(self.central_widget)
+        self.widgets.resp_rate["label"].setObjectName("resp_rate_label")
+        self.grid_layout.addWidget(self.widgets.resp_rate["label"], 15, 0, 1, 1)
+
+        self.widgets.resp_rate["lcd"] = QtWidgets.QLCDNumber(self.central_widget)
+        self.widgets.resp_rate["lcd"].setObjectName("resp_rate_lcd")
+        self.grid_layout.addWidget(self.widgets.resp_rate["lcd"], 15, 2, 1, 1)
+
+        self.widgets.resp_rate["slider"] = QtWidgets.QSlider(self.central_widget)
+        self.widgets.resp_rate["slider"].setOrientation(QtCore.Qt.Horizontal)
+        self.widgets.resp_rate["slider"].setObjectName("resp_rate_slider")
+        self.grid_layout.addWidget(self.widgets.resp_rate["slider"], 15, 3, 1, 1)
+        self.grid_layout.addItem(spacer_item["9"], 6, 2, 1, 1)
+
+    def retranslate_ui(self, main_window) -> None:
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "MainWindow"))
-        self.plateau_press_label.setText(_translate("MainWindow", "Plateau Pressure"))
-        self.tv_label.setText(_translate("MainWindow", "Tidal Volume"))
-        self.ie_label.setText(_translate("MainWindow", "I/E Ratio"))
-        self.resp_rate_label.setText(_translate("MainWindow", "Resp. Rate"))
-        self.fio2_label.setText(_translate("MainWindow", "FiO2"))
-        self.mode_button.setText(_translate("MainWindow", "SIMV"))
-        self.mode_label.setText(_translate("MainWindow", "Mode"))
-        self.peak_press_label.setText(_translate("MainWindow", "Peak. Inspiratory Pressure"))
-        self.peep_label.setText(_translate("MainWindow", "PEEP"))
+        main_window.setWindowTitle(_translate("MainWindow", "MainWindow"))
+        self.widgets.plateau_press["label"].setText(
+            _translate("MainWindow", "Plateau Pressure"))
+        self.widgets.tv["label"].setText(_translate("MainWindow", "Tidal Volume"))
+        self.widgets.ie["label"].setText(_translate("MainWindow", "I/E Ratio"))
+        self.widgets.resp_rate["label"].setText(_translate("MainWindow", "Resp. Rate"))
+        self.widgets.fio2["label"].setText(_translate("MainWindow", "FiO2"))
+        self.widgets.mode["button"].setText(_translate("MainWindow", "SIMV"))
+        self.widgets.mode["label"].setText(_translate("MainWindow", "Mode"))
+        self.widgets.peak_press["label"].setText(
+            _translate("MainWindow", "Peak. Inspiratory Pressure"))
+        self.widgets.peep["label"].setText(_translate("MainWindow", "PEEP"))

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,6 @@
 import json
 
+
 class AqualungSettings():
     def __init__(self):
         self.__mode = False #mode = True -> AC, mode = False -> SIMV
@@ -75,7 +76,6 @@ class AqualungSettings():
     @plateau_press.setter
     def plateau_press(self, value):
         self.__plateau_press = value
-
 
     def toJSON(self):
         j = {}

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 import json
 
-class AqualungSettings:
+class AqualungSettings():
     def __init__(self):
         self.__mode = False #mode = True -> AC, mode = False -> SIMV
         self.__peep = 0

--- a/widgets.py
+++ b/widgets.py
@@ -1,0 +1,38 @@
+class AquaWidgets():
+    def __init__(self):
+        self.mode = {
+            "label": None,
+            "button": None,
+        }
+        self.peep = {
+            "label": None,
+            "lcd": None,
+        }
+        self.peak_press = {
+            "label": None,
+            "lcd": None,
+        }
+        self.plateau_press = {
+            "label": None,
+            "lcd": None,
+        }
+        self.tv = {
+            "label": None,
+            "lcd": None,
+            "slider": None,
+        }
+        self.ie = {
+            "label": None,
+            "lcd": None,
+            "slider": None,
+        }
+        self.fio2 = {
+            "label": None,
+            "lcd": None,
+            "slider": None,
+        }
+        self.resp_rate = {
+            "label": None,
+            "lcd": None,
+            "slider": None,
+        }


### PR DESCRIPTION
Hey everyone,

I have added fixes for the software side of the project to more conform to Python3 PIP standards as well as modularize the code more for easy fixes to UI and such.

One thing I wanted to ask is why `MainWindow` is used as an argument for `UIMainWindow`? It could be confusing for some future users that may use the code. My suggestion is to move the definition of `self.central_widget` and `self.grid_layout` onto the child `AqualungUI` class. In essence, the inheritance structure so far is kind of off.

The other roboticists and I will assist with developing the motor controllers soon. Hope to talk to you all soon!

Regards,

Zahi (Intel EGI)