### PR TITLE
Created UI Initialization Functions instead of Keeping them Methods

### DIFF
--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -1,0 +1,284 @@
+"""
+Widgets used to initialze the the OVVE UI
+"""
+from random import randint
+
+import numpy as np
+import pyqtgraph as pg
+
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
+
+
+def initializeHomeScreenWidget(window) -> None:
+    """ Creates Home Screen for Widgets """
+    h_box_1 = QHBoxLayout()
+
+    v_box_1left = QVBoxLayout()
+    v_box_1mid = QVBoxLayout()
+    v_box_1right = QVBoxLayout()
+
+    window.mode_button_main = window.makeSimpleDisplayButton(
+        window.settings.get_mode_display())
+    window.mode_button_main.clicked.connect(lambda: window.display(1))
+
+    window.resp_rate_button_main = window.makeFancyDisplayButton(
+        "Resp. Rate", window.settings.resp_rate, "b/min")
+    window.resp_rate_button_main.clicked.connect(lambda: window.display(2))
+
+    window.minute_vol_button_main = window.makeFancyDisplayButton(
+        "Minute Volume",
+        window.settings.minute_volume,
+        "l/min",
+    )
+    window.minute_vol_button_main.clicked.connect(lambda: window.display(3))
+
+    window.ie_button_main = window.makeFancyDisplayButton(
+        "I/E Ratio",
+        window.settings.get_ie_display(),
+        "l/min",
+    )
+    window.ie_button_main.clicked.connect(lambda: window.display(4))
+
+    window.peep_display_main = window.makeDisplayRect(
+        "PEEP",
+        5,
+        "cmH2O",
+    )
+    window.tv_insp_display_main = window.makeDisplayRect(
+        "TV Insp",
+        window.params.tv_insp,
+        "mL",
+    )
+    window.tv_exp_display_main = window.makeDisplayRect(
+        "TV Exp",
+        window.params.tv_exp,
+        "mL",
+    )
+    window.ppeak_display_main = window.makeDisplayRect(
+        "Ppeak",
+        window.params.ppeak,
+        "cmH2O",
+    )
+    window.pplat_display_main = window.makeDisplayRect(
+        "Pplat",
+        window.params.pplat,
+        "cmH2O",
+    )
+
+    axisStyle = {'color': 'black', 'font-size': '20pt'}
+    graph_pen = pg.mkPen(width=5, color="b")
+
+    graph_width = 400
+    window.tv_insp_data = np.linspace(0, 0, graph_width)
+    window.flow_graph_ptr = -graph_width
+
+    # TODO: current graph system doesn't associate y values with x values.
+    #       Need to fix?
+    window.flow_graph = pg.PlotWidget()
+    window.flow_graph.setFixedWidth(graph_width)
+    window.flow_graph_line = window.flow_graph.plot(
+        window.tv_insp_data,
+        pen=graph_pen)  # shows Serial (tv_insp) data for now
+    window.flow_graph.setBackground("w")
+    window.flow_graph.setMouseEnabled(False, False)
+    flow_graph_left_axis = window.flow_graph.getAxis("left")
+    flow_graph_left_axis.setLabel("Flow", **axisStyle)  # TODO: Add units
+
+    indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    data = [randint(-10, 10) for _ in range(10)]
+
+    window.pressure_graph = pg.PlotWidget()
+    window.pressure_graph.setFixedWidth(graph_width)
+    window.pressure_graph_line = window.pressure_graph.plot(indices,
+                                                        data,
+                                                        pen=graph_pen)
+    window.pressure_graph.setBackground("w")
+    window.pressure_graph.setMouseEnabled(False, False)
+    pressure_graph_left_axis = window.pressure_graph.getAxis("left")
+    pressure_graph_left_axis.setLabel("Pressure",
+                                        **axisStyle)  # TODO: Add units
+
+    window.volume_graph = pg.PlotWidget()
+    window.volume_graph.setFixedWidth(graph_width)
+    window.pressure_graph_line = window.volume_graph.plot(indices,
+                                                        data,
+                                                        pen=graph_pen)
+    window.volume_graph.setBackground("w")
+    window.volume_graph.setMouseEnabled(False, False)
+    window.pressure_graph_left_axis = window.volume_graph.getAxis("left")
+    window.pressure_graph_left_axis.setLabel("Volume",
+                                            **axisStyle)  # TODO: Add units
+
+    v_box_1left.addWidget(window.mode_button_main)
+    v_box_1left.addWidget(window.resp_rate_button_main)
+    v_box_1left.addWidget(window.minute_vol_button_main)
+    v_box_1left.addWidget(window.ie_button_main)
+    v_box_1left.addWidget(window.peep_display_main)
+
+    v_box_1mid.addWidget(window.flow_graph)
+    v_box_1mid.addWidget(window.pressure_graph)
+    v_box_1mid.addWidget(window.volume_graph)
+
+    v_box_1right.addWidget(window.tv_insp_display_main)
+    v_box_1right.addWidget(window.tv_exp_display_main)
+    v_box_1right.addWidget(window.ppeak_display_main)
+    v_box_1right.addWidget(window.pplat_display_main)
+
+    h_box_1.addLayout(v_box_1left)
+    h_box_1.addLayout(v_box_1mid)
+    h_box_1.addLayout(v_box_1right)
+    window.page["1"].setLayout(h_box_1)
+
+def initializeModeWidget(window) -> None:
+    """ Creates Mode Widget """
+    v_box_2 = QVBoxLayout()
+    h_box_2top = QHBoxLayout()
+    h_box_2middle = QHBoxLayout()
+    h_box_2bottom = QHBoxLayout()
+
+    mode_change = window.makeSimpleDisplayButton("CHANGE MODE")
+    mode_apply = window.makeSimpleDisplayButton("APPLY")
+    mode_cancel = window.makeSimpleDisplayButton("CANCEL")
+
+    mode_change.clicked.connect(
+        lambda: window.changeMode(not window.local_settings.ac_mode))
+    mode_apply.clicked.connect(lambda: window.commitMode())
+    mode_cancel.clicked.connect(window.cancelChange)
+
+    window.mode_page_rect = window.makeDisplayRect(
+        "Mode",
+        window.local_settings.get_mode_display(),
+        "",
+        size=(500, 200))
+
+    h_box_2top.addWidget(window.mode_page_rect)
+    h_box_2middle.addWidget(mode_change)
+    h_box_2bottom.addWidget(mode_apply)
+    h_box_2bottom.addWidget(mode_cancel)
+
+    v_box_2.addLayout(h_box_2top)
+    v_box_2.addLayout(h_box_2middle)
+    v_box_2.addLayout(h_box_2bottom)
+
+    window.page["2"].setLayout(v_box_2)
+
+def initializeRespitoryRateWidget(window) -> None:
+    """ Creates Respitory Rate Widget """
+    v_box_3 = QVBoxLayout()
+    h_box_3top = QHBoxLayout()
+    h_box_3mid = QHBoxLayout()
+    h_box_3bottom = QHBoxLayout()
+
+    window.resp_rate_page_rect = window.makeDisplayRect(
+        "Resp. Rate",
+        window.local_settings.resp_rate,
+        "b/min",
+        size=(500, 200))
+
+    resp_rate_increment_button = window.makeSimpleDisplayButton(
+        "+ " + str(window.settings.resp_rate_increment))
+    resp_rate_decrement_button = window.makeSimpleDisplayButton(
+        "- " + str(window.settings.resp_rate_increment))
+    resp_rate_apply = window.makeSimpleDisplayButton("APPLY")
+    resp_rate_cancel = window.makeSimpleDisplayButton("CANCEL")
+
+    resp_rate_increment_button.clicked.connect(window.incrementRespRate)
+    resp_rate_decrement_button.clicked.connect(window.decrementRespRate)
+    resp_rate_apply.clicked.connect(window.commitRespRate)
+    resp_rate_cancel.clicked.connect(window.cancelChange)
+
+    h_box_3top.addWidget(window.resp_rate_page_rect)
+    h_box_3mid.addWidget(resp_rate_increment_button)
+    h_box_3mid.addWidget(resp_rate_decrement_button)
+    h_box_3bottom.addWidget(resp_rate_apply)
+    h_box_3bottom.addWidget(resp_rate_cancel)
+
+    v_box_3.addLayout(h_box_3top)
+    v_box_3.addLayout(h_box_3mid)
+    v_box_3.addLayout(h_box_3bottom)
+
+    window.page["3"].setLayout(v_box_3)
+
+def initializeMinuteVolumeWidget(window):
+    """ Creates Minute Volume Widget """
+    v_box_4 = QVBoxLayout()
+    h_box_4top = QHBoxLayout()
+    h_box_4mid = QHBoxLayout()
+    h_box_4bottom = QHBoxLayout()
+
+    window.minute_vol_page_rect = window.makeDisplayRect(
+        "Minute Volume",
+        window.local_settings.minute_volume,
+        "l/min",
+        size=(500, 200))
+
+    minute_vol_increment_button = window.makeSimpleDisplayButton(
+        "+ " + str(window.settings.minute_volume_increment))
+    minute_vol_decrement_button = window.makeSimpleDisplayButton(
+        "- " + str(window.settings.minute_volume_increment))
+    minute_vol_apply = window.makeSimpleDisplayButton("APPLY")
+    minute_vol_cancel = window.makeSimpleDisplayButton("CANCEL")
+
+    minute_vol_increment_button.clicked.connect(window.incrementMinuteVol)
+    minute_vol_decrement_button.clicked.connect(window.decrementMinuteVol)
+    minute_vol_apply.clicked.connect(window.commitMinuteVol)
+    minute_vol_cancel.clicked.connect(window.cancelChange)
+
+    h_box_4top.addWidget(window.minute_vol_page_rect)
+    h_box_4mid.addWidget(minute_vol_increment_button)
+    h_box_4mid.addWidget(minute_vol_decrement_button)
+    h_box_4bottom.addWidget(minute_vol_apply)
+    h_box_4bottom.addWidget(minute_vol_cancel)
+
+    v_box_4.addLayout(h_box_4top)
+    v_box_4.addLayout(h_box_4mid)
+    v_box_4.addLayout(h_box_4bottom)
+
+    window.page["4"].setLayout(v_box_4)
+
+def initializeIERatioWidget(window):
+    """ Creates i/e Ratio Widget """
+    v_box_5 = QVBoxLayout()
+    h_box_5top = QHBoxLayout()
+    h_box_5mid = QHBoxLayout()
+    h_box_5bottom = QHBoxLayout()
+
+    window.ie_page_rect = window.makeDisplayRect(
+        "I/E Ratio", window.settings.get_ie_display(), "", size=(500, 200))
+
+    ie_change_size = (150, 50)
+
+    ie_change_0 = window.makeSimpleDisplayButton(
+        window.settings.ie_ratio_display[0], size=ie_change_size)
+    ie_change_1 = window.makeSimpleDisplayButton(
+        window.settings.ie_ratio_display[1], size=ie_change_size)
+    ie_change_2 = window.makeSimpleDisplayButton(
+        window.settings.ie_ratio_display[2], size=ie_change_size)
+    ie_change_3 = window.makeSimpleDisplayButton(
+        window.settings.ie_ratio_display[3], size=ie_change_size)
+
+    ie_apply = window.makeSimpleDisplayButton("APPLY")
+    ie_cancel = window.makeSimpleDisplayButton("CANCEL")
+
+    ie_change_0.clicked.connect(lambda: window.changeIERatio(0))
+    ie_change_1.clicked.connect(lambda: window.changeIERatio(1))
+    ie_change_2.clicked.connect(lambda: window.changeIERatio(2))
+    ie_change_3.clicked.connect(lambda: window.changeIERatio(3))
+
+    ie_apply.clicked.connect(window.commitIERatio)
+    ie_cancel.clicked.connect(window.cancelChange)
+
+    h_box_5top.addWidget(window.ie_page_rect)
+    h_box_5mid.addWidget(ie_change_0)
+    h_box_5mid.addWidget(ie_change_1)
+    h_box_5mid.addWidget(ie_change_2)
+    h_box_5mid.addWidget(ie_change_3)
+
+    h_box_5bottom.addWidget(ie_apply)
+    h_box_5bottom.addWidget(ie_cancel)
+
+    v_box_5.addLayout(h_box_5top)
+    v_box_5.addLayout(h_box_5mid)
+    v_box_5.addLayout(h_box_5bottom)
+
+    window.page["5"].setLayout(v_box_5)

--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -100,7 +100,9 @@ def initializeHomeScreenWidget(window) -> None:
     h_box.addLayout(v_box_left)
     h_box.addLayout(v_box_mid)
     h_box.addLayout(v_box_right)
+    
     window.page["1"].setLayout(h_box)
+
 
 def initializeModeWidget(window) -> None:
     """ Creates Mode Widget """
@@ -131,6 +133,7 @@ def initializeModeWidget(window) -> None:
     v_box.addLayout(h_box_bot)
 
     window.page["2"].setLayout(v_box)
+
 
 def initializeRespitoryRateWidget(window) -> None:
     """ Creates Respitory Rate Widget """
@@ -205,6 +208,7 @@ def initializeMinuteVolumeWidget(window):
     v_box.addLayout(h_box_bot)
 
     window.page["4"].setLayout(v_box)
+
 
 def initializeIERatioWidget(window):
     """ Creates i/e Ratio Widget """

--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -2,6 +2,7 @@
 Widgets used to initialze the the OVVE UI
 """
 from random import randint
+from typing import TypeVar
 
 import numpy as np
 import pyqtgraph as pg
@@ -9,7 +10,11 @@ import pyqtgraph as pg
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 
-def initializeHomeScreenWidget(window) -> None:
+# Used for documentation purposes only
+MainWindow = TypeVar('MainWindow')
+
+
+def initializeHomeScreenWidget(window: MainWindow) -> None:
     """ Creates Home Screen for Widgets """
     h_box = QHBoxLayout()
     v_box_left = QVBoxLayout()
@@ -104,7 +109,7 @@ def initializeHomeScreenWidget(window) -> None:
     window.page["1"].setLayout(h_box)
 
 
-def initializeModeWidget(window) -> None:
+def initializeModeWidget(window: MainWindow) -> None:
     """ Creates Mode Widget """
     v_box = QVBoxLayout()
     h_box_top = QHBoxLayout()
@@ -172,7 +177,7 @@ def initializeRespitoryRateWidget(window) -> None:
 
     window.page["3"].setLayout(v_box)
 
-def initializeMinuteVolumeWidget(window):
+def initializeMinuteVolumeWidget(window: MainWindow):
     """ Creates Minute Volume Widget """
     v_box = QVBoxLayout()
     h_box_top = QHBoxLayout()
@@ -210,7 +215,7 @@ def initializeMinuteVolumeWidget(window):
     window.page["4"].setLayout(v_box)
 
 
-def initializeIERatioWidget(window):
+def initializeIERatioWidget(window: MainWindow):
     """ Creates i/e Ratio Widget """
     v_box = QVBoxLayout()
     h_box_top = QHBoxLayout()

--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -11,11 +11,10 @@ from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 def initializeHomeScreenWidget(window) -> None:
     """ Creates Home Screen for Widgets """
-    h_box_1 = QHBoxLayout()
-
-    v_box_1left = QVBoxLayout()
-    v_box_1mid = QVBoxLayout()
-    v_box_1right = QVBoxLayout()
+    h_box = QHBoxLayout()
+    v_box_left = QVBoxLayout()
+    v_box_mid = QVBoxLayout()
+    v_box_right = QVBoxLayout()
 
     window.mode_button_main = window.makeSimpleDisplayButton(
         window.settings.get_mode_display())
@@ -26,44 +25,23 @@ def initializeHomeScreenWidget(window) -> None:
     window.resp_rate_button_main.clicked.connect(lambda: window.display(2))
 
     window.minute_vol_button_main = window.makeFancyDisplayButton(
-        "Minute Volume",
-        window.settings.minute_volume,
-        "l/min",
-    )
+        "Minute Volume", window.settings.minute_volume, "l/min")
     window.minute_vol_button_main.clicked.connect(lambda: window.display(3))
 
     window.ie_button_main = window.makeFancyDisplayButton(
-        "I/E Ratio",
-        window.settings.get_ie_display(),
-        "l/min",
-    )
+        "I/E Ratio", window.settings.get_ie_display(), "l/min")
     window.ie_button_main.clicked.connect(lambda: window.display(4))
 
     window.peep_display_main = window.makeDisplayRect(
-        "PEEP",
-        5,
-        "cmH2O",
-    )
+        "PEEP", 5, "cmH2O")
     window.tv_insp_display_main = window.makeDisplayRect(
-        "TV Insp",
-        window.params.tv_insp,
-        "mL",
-    )
+        "TV Insp", window.params.tv_insp, "mL")
     window.tv_exp_display_main = window.makeDisplayRect(
-        "TV Exp",
-        window.params.tv_exp,
-        "mL",
-    )
+        "TV Exp", window.params.tv_exp, "mL")
     window.ppeak_display_main = window.makeDisplayRect(
-        "Ppeak",
-        window.params.ppeak,
-        "cmH2O",
-    )
+        "Ppeak", window.params.ppeak, "cmH2O")
     window.pplat_display_main = window.makeDisplayRect(
-        "Pplat",
-        window.params.pplat,
-        "cmH2O",
-    )
+        "Pplat", window.params.pplat, "cmH2O")
 
     axisStyle = {'color': 'black', 'font-size': '20pt'}
     graph_pen = pg.mkPen(width=5, color="b")
@@ -77,8 +55,7 @@ def initializeHomeScreenWidget(window) -> None:
     window.flow_graph = pg.PlotWidget()
     window.flow_graph.setFixedWidth(graph_width)
     window.flow_graph_line = window.flow_graph.plot(
-        window.tv_insp_data,
-        pen=graph_pen)  # shows Serial (tv_insp) data for now
+        window.tv_insp_data, pen=graph_pen)  # shows Serial (tv_insp) data for now
     window.flow_graph.setBackground("w")
     window.flow_graph.setMouseEnabled(False, False)
     flow_graph_left_axis = window.flow_graph.getAxis("left")
@@ -89,52 +66,48 @@ def initializeHomeScreenWidget(window) -> None:
 
     window.pressure_graph = pg.PlotWidget()
     window.pressure_graph.setFixedWidth(graph_width)
-    window.pressure_graph_line = window.pressure_graph.plot(indices,
-                                                        data,
-                                                        pen=graph_pen)
+    window.pressure_graph_line = window.pressure_graph.plot(
+        indices, data, pen=graph_pen)
     window.pressure_graph.setBackground("w")
     window.pressure_graph.setMouseEnabled(False, False)
     pressure_graph_left_axis = window.pressure_graph.getAxis("left")
-    pressure_graph_left_axis.setLabel("Pressure",
-                                        **axisStyle)  # TODO: Add units
+    pressure_graph_left_axis.setLabel("Pressure", **axisStyle)  # TODO: Add units
 
     window.volume_graph = pg.PlotWidget()
     window.volume_graph.setFixedWidth(graph_width)
-    window.pressure_graph_line = window.volume_graph.plot(indices,
-                                                        data,
-                                                        pen=graph_pen)
+    window.pressure_graph_line = window.volume_graph.plot(
+        indices, data, pen=graph_pen)
     window.volume_graph.setBackground("w")
     window.volume_graph.setMouseEnabled(False, False)
     window.pressure_graph_left_axis = window.volume_graph.getAxis("left")
-    window.pressure_graph_left_axis.setLabel("Volume",
-                                            **axisStyle)  # TODO: Add units
+    window.pressure_graph_left_axis.setLabel("Volume", **axisStyle)  # TODO: Add units
 
-    v_box_1left.addWidget(window.mode_button_main)
-    v_box_1left.addWidget(window.resp_rate_button_main)
-    v_box_1left.addWidget(window.minute_vol_button_main)
-    v_box_1left.addWidget(window.ie_button_main)
-    v_box_1left.addWidget(window.peep_display_main)
+    v_box_left.addWidget(window.mode_button_main)
+    v_box_left.addWidget(window.resp_rate_button_main)
+    v_box_left.addWidget(window.minute_vol_button_main)
+    v_box_left.addWidget(window.ie_button_main)
+    v_box_left.addWidget(window.peep_display_main)
 
-    v_box_1mid.addWidget(window.flow_graph)
-    v_box_1mid.addWidget(window.pressure_graph)
-    v_box_1mid.addWidget(window.volume_graph)
+    v_box_mid.addWidget(window.flow_graph)
+    v_box_mid.addWidget(window.pressure_graph)
+    v_box_mid.addWidget(window.volume_graph)
 
-    v_box_1right.addWidget(window.tv_insp_display_main)
-    v_box_1right.addWidget(window.tv_exp_display_main)
-    v_box_1right.addWidget(window.ppeak_display_main)
-    v_box_1right.addWidget(window.pplat_display_main)
+    v_box_right.addWidget(window.tv_insp_display_main)
+    v_box_right.addWidget(window.tv_exp_display_main)
+    v_box_right.addWidget(window.ppeak_display_main)
+    v_box_right.addWidget(window.pplat_display_main)
 
-    h_box_1.addLayout(v_box_1left)
-    h_box_1.addLayout(v_box_1mid)
-    h_box_1.addLayout(v_box_1right)
-    window.page["1"].setLayout(h_box_1)
+    h_box.addLayout(v_box_left)
+    h_box.addLayout(v_box_mid)
+    h_box.addLayout(v_box_right)
+    window.page["1"].setLayout(h_box)
 
 def initializeModeWidget(window) -> None:
     """ Creates Mode Widget """
-    v_box_2 = QVBoxLayout()
-    h_box_2top = QHBoxLayout()
-    h_box_2middle = QHBoxLayout()
-    h_box_2bottom = QHBoxLayout()
+    v_box = QVBoxLayout()
+    h_box_top = QHBoxLayout()
+    h_box_mid= QHBoxLayout()
+    h_box_bot = QHBoxLayout()
 
     mode_change = window.makeSimpleDisplayButton("CHANGE MODE")
     mode_apply = window.makeSimpleDisplayButton("APPLY")
@@ -146,28 +119,25 @@ def initializeModeWidget(window) -> None:
     mode_cancel.clicked.connect(window.cancelChange)
 
     window.mode_page_rect = window.makeDisplayRect(
-        "Mode",
-        window.local_settings.get_mode_display(),
-        "",
-        size=(500, 200))
+        "Mode", window.local_settings.get_mode_display(), "", size=(500, 200))
 
-    h_box_2top.addWidget(window.mode_page_rect)
-    h_box_2middle.addWidget(mode_change)
-    h_box_2bottom.addWidget(mode_apply)
-    h_box_2bottom.addWidget(mode_cancel)
+    h_box_top.addWidget(window.mode_page_rect)
+    h_box_mid.addWidget(mode_change)
+    h_box_bot.addWidget(mode_apply)
+    h_box_bot.addWidget(mode_cancel)
 
-    v_box_2.addLayout(h_box_2top)
-    v_box_2.addLayout(h_box_2middle)
-    v_box_2.addLayout(h_box_2bottom)
+    v_box.addLayout(h_box_top)
+    v_box.addLayout(h_box_mid)
+    v_box.addLayout(h_box_bot)
 
-    window.page["2"].setLayout(v_box_2)
+    window.page["2"].setLayout(v_box)
 
 def initializeRespitoryRateWidget(window) -> None:
     """ Creates Respitory Rate Widget """
-    v_box_3 = QVBoxLayout()
-    h_box_3top = QHBoxLayout()
-    h_box_3mid = QHBoxLayout()
-    h_box_3bottom = QHBoxLayout()
+    v_box = QVBoxLayout()
+    h_box_top = QHBoxLayout()
+    h_box_mid = QHBoxLayout()
+    h_box_bot = QHBoxLayout()
 
     window.resp_rate_page_rect = window.makeDisplayRect(
         "Resp. Rate",
@@ -187,24 +157,24 @@ def initializeRespitoryRateWidget(window) -> None:
     resp_rate_apply.clicked.connect(window.commitRespRate)
     resp_rate_cancel.clicked.connect(window.cancelChange)
 
-    h_box_3top.addWidget(window.resp_rate_page_rect)
-    h_box_3mid.addWidget(resp_rate_increment_button)
-    h_box_3mid.addWidget(resp_rate_decrement_button)
-    h_box_3bottom.addWidget(resp_rate_apply)
-    h_box_3bottom.addWidget(resp_rate_cancel)
+    h_box_top.addWidget(window.resp_rate_page_rect)
+    h_box_mid.addWidget(resp_rate_increment_button)
+    h_box_mid.addWidget(resp_rate_decrement_button)
+    h_box_bot.addWidget(resp_rate_apply)
+    h_box_bot.addWidget(resp_rate_cancel)
 
-    v_box_3.addLayout(h_box_3top)
-    v_box_3.addLayout(h_box_3mid)
-    v_box_3.addLayout(h_box_3bottom)
+    v_box.addLayout(h_box_top)
+    v_box.addLayout(h_box_mid)
+    v_box.addLayout(h_box_bot)
 
-    window.page["3"].setLayout(v_box_3)
+    window.page["3"].setLayout(v_box)
 
 def initializeMinuteVolumeWidget(window):
     """ Creates Minute Volume Widget """
-    v_box_4 = QVBoxLayout()
-    h_box_4top = QHBoxLayout()
-    h_box_4mid = QHBoxLayout()
-    h_box_4bottom = QHBoxLayout()
+    v_box = QVBoxLayout()
+    h_box_top = QHBoxLayout()
+    h_box_mid = QHBoxLayout()
+    h_box_bot = QHBoxLayout()
 
     window.minute_vol_page_rect = window.makeDisplayRect(
         "Minute Volume",
@@ -224,24 +194,24 @@ def initializeMinuteVolumeWidget(window):
     minute_vol_apply.clicked.connect(window.commitMinuteVol)
     minute_vol_cancel.clicked.connect(window.cancelChange)
 
-    h_box_4top.addWidget(window.minute_vol_page_rect)
-    h_box_4mid.addWidget(minute_vol_increment_button)
-    h_box_4mid.addWidget(minute_vol_decrement_button)
-    h_box_4bottom.addWidget(minute_vol_apply)
-    h_box_4bottom.addWidget(minute_vol_cancel)
+    h_box_top.addWidget(window.minute_vol_page_rect)
+    h_box_mid.addWidget(minute_vol_increment_button)
+    h_box_mid.addWidget(minute_vol_decrement_button)
+    h_box_bot.addWidget(minute_vol_apply)
+    h_box_bot.addWidget(minute_vol_cancel)
 
-    v_box_4.addLayout(h_box_4top)
-    v_box_4.addLayout(h_box_4mid)
-    v_box_4.addLayout(h_box_4bottom)
+    v_box.addLayout(h_box_top)
+    v_box.addLayout(h_box_mid)
+    v_box.addLayout(h_box_bot)
 
-    window.page["4"].setLayout(v_box_4)
+    window.page["4"].setLayout(v_box)
 
 def initializeIERatioWidget(window):
     """ Creates i/e Ratio Widget """
-    v_box_5 = QVBoxLayout()
-    h_box_5top = QHBoxLayout()
-    h_box_5mid = QHBoxLayout()
-    h_box_5bottom = QHBoxLayout()
+    v_box = QVBoxLayout()
+    h_box_top = QHBoxLayout()
+    h_box_mid = QHBoxLayout()
+    h_box_bot = QHBoxLayout()
 
     window.ie_page_rect = window.makeDisplayRect(
         "I/E Ratio", window.settings.get_ie_display(), "", size=(500, 200))
@@ -268,17 +238,17 @@ def initializeIERatioWidget(window):
     ie_apply.clicked.connect(window.commitIERatio)
     ie_cancel.clicked.connect(window.cancelChange)
 
-    h_box_5top.addWidget(window.ie_page_rect)
-    h_box_5mid.addWidget(ie_change_0)
-    h_box_5mid.addWidget(ie_change_1)
-    h_box_5mid.addWidget(ie_change_2)
-    h_box_5mid.addWidget(ie_change_3)
+    h_box_top.addWidget(window.ie_page_rect)
+    h_box_mid.addWidget(ie_change_0)
+    h_box_mid.addWidget(ie_change_1)
+    h_box_mid.addWidget(ie_change_2)
+    h_box_mid.addWidget(ie_change_3)
 
-    h_box_5bottom.addWidget(ie_apply)
-    h_box_5bottom.addWidget(ie_cancel)
+    h_box_bot.addWidget(ie_apply)
+    h_box_bot.addWidget(ie_cancel)
 
-    v_box_5.addLayout(h_box_5top)
-    v_box_5.addLayout(h_box_5mid)
-    v_box_5.addLayout(h_box_5bottom)
+    v_box.addLayout(h_box_top)
+    v_box.addLayout(h_box_mid)
+    v_box.addLayout(h_box_bot)
 
-    window.page["5"].setLayout(v_box_5)
+    window.page["5"].setLayout(v_box)

--- a/ovve_ui/ovve_ui.py
+++ b/ovve_ui/ovve_ui.py
@@ -20,8 +20,14 @@ from display.change import Change
 from display.rectangle import DisplayRect
 from display.ui_settings import (DisplayRectSettings,
                                  FancyButtonSettings,
-                                 SimpleButtonSettings, TextSetting,
+                                 SimpleButtonSettings,
+                                 TextSetting,
                                  UISettings)
+from display.widgets import (initializeHomeScreenWidget,
+                             initializeModeWidget,
+                             initializeRespitoryRateWidget,
+                             initializeMinuteVolumeWidget,
+                             initializeIERatioWidget)
 from utils.params import Params
 from utils.settings import Settings
 
@@ -101,291 +107,22 @@ class MainWindow(QWidget):
             rect_settings=self.ui_settings.display_rect_settings)
 
     def initalizeAndAddStackWidgets(self) -> None:
-        self.initializeWidget1()
-        self.initializeWidget2()
-        self.initializeWidget3()
-        self.initializeWidget4()
-        self.initializeWidget5()
+        initializeHomeScreenWidget(self)
+        initializeModeWidget(self)
+        initializeRespitoryRateWidget(self)
+        initializeMinuteVolumeWidget(self)
+        initializeIERatioWidget(self)
         for i in self.page:
             self.stack.addWidget(self.page[i])
 
-    def initializeWidget1(self):  # home screen
-        h_box_1 = QHBoxLayout()
-
-        v_box_1left = QVBoxLayout()
-        v_box_1mid = QVBoxLayout()
-        v_box_1right = QVBoxLayout()
-
-        self.mode_button_main = self.makeSimpleDisplayButton(
-            self.settings.get_mode_display())
-        self.mode_button_main.clicked.connect(lambda: self.display(1))
-
-        self.resp_rate_button_main = self.makeFancyDisplayButton(
-            "Resp. Rate", self.settings.resp_rate, "b/min")
-        self.resp_rate_button_main.clicked.connect(lambda: self.display(2))
-
-        self.minute_vol_button_main = self.makeFancyDisplayButton(
-            "Minute Volume",
-            self.settings.minute_volume,
-            "l/min",
-        )
-        self.minute_vol_button_main.clicked.connect(lambda: self.display(3))
-
-        self.ie_button_main = self.makeFancyDisplayButton(
-            "I/E Ratio",
-            self.settings.get_ie_display(),
-            "l/min",
-        )
-        self.ie_button_main.clicked.connect(lambda: self.display(4))
-
-        self.peep_display_main = self.makeDisplayRect(
-            "PEEP",
-            5,
-            "cmH2O",
-        )
-        self.tv_insp_display_main = self.makeDisplayRect(
-            "TV Insp",
-            self.params.tv_insp,
-            "mL",
-        )
-        self.tv_exp_display_main = self.makeDisplayRect(
-            "TV Exp",
-            self.params.tv_exp,
-            "mL",
-        )
-        self.ppeak_display_main = self.makeDisplayRect(
-            "Ppeak",
-            self.params.ppeak,
-            "cmH2O",
-        )
-        self.pplat_display_main = self.makeDisplayRect(
-            "Pplat",
-            self.params.pplat,
-            "cmH2O",
-        )
-
-        axisStyle = {'color': 'black', 'font-size': '20pt'}
-        graph_pen = pg.mkPen(width=5, color="b")
-
-        graph_width = 400
-        self.tv_insp_data = np.linspace(0, 0, graph_width)
-        self.flow_graph_ptr = -graph_width
-
-        # TODO: current graph system doesn't associate y values with x values.
-        #       Need to fix?
-        self.flow_graph = pg.PlotWidget()
-        self.flow_graph.setFixedWidth(graph_width)
-        self.flow_graph_line = self.flow_graph.plot(
-            self.tv_insp_data,
-            pen=graph_pen)  # shows Serial (tv_insp) data for now
-        self.flow_graph.setBackground("w")
-        self.flow_graph.setMouseEnabled(False, False)
-        flow_graph_left_axis = self.flow_graph.getAxis("left")
-        flow_graph_left_axis.setLabel("Flow", **axisStyle)  # TODO: Add units
-
-        indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        data = [randint(-10, 10) for _ in range(10)]
-
-        self.pressure_graph = pg.PlotWidget()
-        self.pressure_graph.setFixedWidth(graph_width)
-        self.pressure_graph_line = self.pressure_graph.plot(indices,
-                                                            data,
-                                                            pen=graph_pen)
-        self.pressure_graph.setBackground("w")
-        self.pressure_graph.setMouseEnabled(False, False)
-        pressure_graph_left_axis = self.pressure_graph.getAxis("left")
-        pressure_graph_left_axis.setLabel("Pressure",
-                                          **axisStyle)  # TODO: Add units
-
-        self.volume_graph = pg.PlotWidget()
-        self.volume_graph.setFixedWidth(graph_width)
-        self.pressure_graph_line = self.volume_graph.plot(indices,
-                                                          data,
-                                                          pen=graph_pen)
-        self.volume_graph.setBackground("w")
-        self.volume_graph.setMouseEnabled(False, False)
-        self.pressure_graph_left_axis = self.volume_graph.getAxis("left")
-        self.pressure_graph_left_axis.setLabel("Volume",
-                                               **axisStyle)  # TODO: Add units
-
-        v_box_1left.addWidget(self.mode_button_main)
-        v_box_1left.addWidget(self.resp_rate_button_main)
-        v_box_1left.addWidget(self.minute_vol_button_main)
-        v_box_1left.addWidget(self.ie_button_main)
-        v_box_1left.addWidget(self.peep_display_main)
-
-        v_box_1mid.addWidget(self.flow_graph)
-        v_box_1mid.addWidget(self.pressure_graph)
-        v_box_1mid.addWidget(self.volume_graph)
-
-        v_box_1right.addWidget(self.tv_insp_display_main)
-        v_box_1right.addWidget(self.tv_exp_display_main)
-        v_box_1right.addWidget(self.ppeak_display_main)
-        v_box_1right.addWidget(self.pplat_display_main)
-
-        h_box_1.addLayout(v_box_1left)
-        h_box_1.addLayout(v_box_1mid)
-        h_box_1.addLayout(v_box_1right)
-        self.page["1"].setLayout(h_box_1)
-
-    def initializeWidget2(self):  # Mode
-        v_box_2 = QVBoxLayout()
-        h_box_2top = QHBoxLayout()
-        h_box_2middle = QHBoxLayout()
-        h_box_2bottom = QHBoxLayout()
-
-        mode_change = self.makeSimpleDisplayButton("CHANGE MODE")
-        mode_apply = self.makeSimpleDisplayButton("APPLY")
-        mode_cancel = self.makeSimpleDisplayButton("CANCEL")
-
-        mode_change.clicked.connect(
-            lambda: self.changeMode(not self.local_settings.ac_mode))
-        mode_apply.clicked.connect(lambda: self.commitMode())
-        mode_cancel.clicked.connect(self.cancelChange)
-
-        self.mode_page_rect = self.makeDisplayRect(
-            "Mode",
-            self.local_settings.get_mode_display(),
-            "",
-            size=(500, 200))
-
-        h_box_2top.addWidget(self.mode_page_rect)
-        h_box_2middle.addWidget(mode_change)
-        h_box_2bottom.addWidget(mode_apply)
-        h_box_2bottom.addWidget(mode_cancel)
-
-        v_box_2.addLayout(h_box_2top)
-        v_box_2.addLayout(h_box_2middle)
-        v_box_2.addLayout(h_box_2bottom)
-
-        self.page["2"].setLayout(v_box_2)
-
-    def initializeWidget3(self):  # Resp_rate
-        v_box_3 = QVBoxLayout()
-        h_box_3top = QHBoxLayout()
-        h_box_3mid = QHBoxLayout()
-        h_box_3bottom = QHBoxLayout()
-
-        self.resp_rate_page_rect = self.makeDisplayRect(
-            "Resp. Rate",
-            self.local_settings.resp_rate,
-            "b/min",
-            size=(500, 200))
-
-        resp_rate_increment_button = self.makeSimpleDisplayButton(
-            "+ " + str(self.settings.resp_rate_increment))
-        resp_rate_decrement_button = self.makeSimpleDisplayButton(
-            "- " + str(self.settings.resp_rate_increment))
-        resp_rate_apply = self.makeSimpleDisplayButton("APPLY")
-        resp_rate_cancel = self.makeSimpleDisplayButton("CANCEL")
-
-        resp_rate_increment_button.clicked.connect(self.incrementRespRate)
-        resp_rate_decrement_button.clicked.connect(self.decrementRespRate)
-        resp_rate_apply.clicked.connect(self.commitRespRate)
-        resp_rate_cancel.clicked.connect(self.cancelChange)
-
-        h_box_3top.addWidget(self.resp_rate_page_rect)
-        h_box_3mid.addWidget(resp_rate_increment_button)
-        h_box_3mid.addWidget(resp_rate_decrement_button)
-        h_box_3bottom.addWidget(resp_rate_apply)
-        h_box_3bottom.addWidget(resp_rate_cancel)
-
-        v_box_3.addLayout(h_box_3top)
-        v_box_3.addLayout(h_box_3mid)
-        v_box_3.addLayout(h_box_3bottom)
-
-        self.page["3"].setLayout(v_box_3)
-
-    def initializeWidget4(self):  # Minute volume
-        v_box_4 = QVBoxLayout()
-        h_box_4top = QHBoxLayout()
-        h_box_4mid = QHBoxLayout()
-        h_box_4bottom = QHBoxLayout()
-
-        self.minute_vol_page_rect = self.makeDisplayRect(
-            "Minute Volume",
-            self.local_settings.minute_volume,
-            "l/min",
-            size=(500, 200))
-
-        minute_vol_increment_button = self.makeSimpleDisplayButton(
-            "+ " + str(self.settings.minute_volume_increment))
-        minute_vol_decrement_button = self.makeSimpleDisplayButton(
-            "- " + str(self.settings.minute_volume_increment))
-        minute_vol_apply = self.makeSimpleDisplayButton("APPLY")
-        minute_vol_cancel = self.makeSimpleDisplayButton("CANCEL")
-
-        minute_vol_increment_button.clicked.connect(self.incrementMinuteVol)
-        minute_vol_decrement_button.clicked.connect(self.decrementMinuteVol)
-        minute_vol_apply.clicked.connect(self.commitMinuteVol)
-        minute_vol_cancel.clicked.connect(self.cancelChange)
-
-        h_box_4top.addWidget(self.minute_vol_page_rect)
-        h_box_4mid.addWidget(minute_vol_increment_button)
-        h_box_4mid.addWidget(minute_vol_decrement_button)
-        h_box_4bottom.addWidget(minute_vol_apply)
-        h_box_4bottom.addWidget(minute_vol_cancel)
-
-        v_box_4.addLayout(h_box_4top)
-        v_box_4.addLayout(h_box_4mid)
-        v_box_4.addLayout(h_box_4bottom)
-
-        self.page["4"].setLayout(v_box_4)
-
-    def initializeWidget5(self):  # ie ratio
-        v_box_5 = QVBoxLayout()
-        h_box_5top = QHBoxLayout()
-        h_box_5mid = QHBoxLayout()
-        h_box_5bottom = QHBoxLayout()
-
-        self.ie_page_rect = self.makeDisplayRect(
-            "I/E Ratio", self.settings.get_ie_display(), "", size=(500, 200))
-
-        ie_change_size = (150, 50)
-
-        ie_change_0 = self.makeSimpleDisplayButton(
-            self.settings.ie_ratio_display[0], size=ie_change_size)
-        ie_change_1 = self.makeSimpleDisplayButton(
-            self.settings.ie_ratio_display[1], size=ie_change_size)
-        ie_change_2 = self.makeSimpleDisplayButton(
-            self.settings.ie_ratio_display[2], size=ie_change_size)
-        ie_change_3 = self.makeSimpleDisplayButton(
-            self.settings.ie_ratio_display[3], size=ie_change_size)
-
-        ie_apply = self.makeSimpleDisplayButton("APPLY")
-        ie_cancel = self.makeSimpleDisplayButton("CANCEL")
-
-        ie_change_0.clicked.connect(lambda: self.changeIERatio(0))
-        ie_change_1.clicked.connect(lambda: self.changeIERatio(1))
-        ie_change_2.clicked.connect(lambda: self.changeIERatio(2))
-        ie_change_3.clicked.connect(lambda: self.changeIERatio(3))
-
-        ie_apply.clicked.connect(self.commitIERatio)
-        ie_cancel.clicked.connect(self.cancelChange)
-
-        h_box_5top.addWidget(self.ie_page_rect)
-        h_box_5mid.addWidget(ie_change_0)
-        h_box_5mid.addWidget(ie_change_1)
-        h_box_5mid.addWidget(ie_change_2)
-        h_box_5mid.addWidget(ie_change_3)
-
-        h_box_5bottom.addWidget(ie_apply)
-        h_box_5bottom.addWidget(ie_cancel)
-
-        v_box_5.addLayout(h_box_5top)
-        v_box_5.addLayout(h_box_5mid)
-        v_box_5.addLayout(h_box_5bottom)
-
-        self.page["5"].setLayout(v_box_5)
-
-    def display(self, i):
+    def display(self, i: int) -> None:
         self.stack.setCurrentIndex(i)
 
-    def update_main_page_ui(self):
+    def update_main_page_ui(self) -> None:
         self.updateMainDisplays()
         self.updateGraphs()
 
-    def updateMainDisplays(self):
+    def updateMainDisplays(self) -> None:
         self.mode_button_main.updateValue(self.settings.get_mode_display())
         self.resp_rate_button_main.updateValue(self.settings.resp_rate)
         self.minute_vol_button_main.updateValue(self.settings.minute_volume)
@@ -396,14 +133,14 @@ class MainWindow(QWidget):
         self.ppeak_display_main.updateValue(self.params.ppeak)
         self.pplat_display_main.updateValue(self.params.pplat)
 
-    def updatePageDisplays(self):
+    def updatePageDisplays(self) -> None:
         self.mode_page_rect.updateValue(self.settings.get_mode_display())
         self.resp_rate_page_rect.updateValue(self.settings.resp_rate)
         self.minute_vol_page_rect.updateValue(self.settings.minute_volume)
         self.ie_page_rect.updateValue(self.settings.get_ie_display())
 
     # TODO: Polish up and process data properly
-    def updateGraphs(self):
+    def updateGraphs(self) -> None:
         self.tv_insp_data[:-1] = self.tv_insp_data[1:]
         self.tv_insp_data[-1] = self.params.tv_insp
         self.flow_graph_line.setData(self.tv_insp_data)
@@ -411,15 +148,15 @@ class MainWindow(QWidget):
         self.flow_graph_line.setPos(self.ptr, 0)
         QtGui.QApplication.processEvents()
 
-    def open_serial(self):
+    def open_serial(self) -> None:
         if not self.serial.isOpen():
             self.serial.open(QtCore.QIODevice.ReadWrite)
 
-    def close_serial(self):
+    def close_serial(self) -> None:
         if self.serial.isOpen():
             self.serial.close()
 
-    def start_serial(self, serialport):
+    def start_serial(self, serialport: str) -> None:
         #TODO: error checking, retry
         self.serial = QtSerialPort.QSerialPort(
             serialport,
@@ -429,7 +166,7 @@ class MainWindow(QWidget):
         self.open_serial()
 
     @QtCore.pyqtSlot()
-    def receive(self):
+    def receive(self) -> None:
         while self.serial.canReadLine():
             text = self.serial.readLine().data().decode()
             text = text.rstrip("\r\n")
@@ -440,37 +177,37 @@ class MainWindow(QWidget):
 
     # TODO: Map add all other input data to proper settings
 
-    def parseInputAndUpdate(self, text):
+    def parseInputAndUpdate(self, text: str) -> None:
         self.params.tv_insp = int(text)
         # print(text)
         self.update_main_page_ui()
 
     # TODO: Finish all of these for each var
-    def changeMode(self, new_val):
+    def changeMode(self, new_val: bool) -> None:
         self.local_settings.ac_mode = new_val
         self.mode_page_rect.updateValue(self.local_settings.get_mode_display())
 
     # TODO: Figure out how to handle increment properly
     # (right now it's not in the settings)
-    def incrementRespRate(self):
+    def incrementRespRate(self) -> None:
         self.local_settings.resp_rate += self.settings.resp_rate_increment
         self.resp_rate_page_rect.updateValue(self.local_settings.resp_rate)
 
-    def decrementRespRate(self):
+    def decrementRespRate(self) -> None:
         self.local_settings.resp_rate -= self.settings.resp_rate_increment
         self.resp_rate_page_rect.updateValue(self.local_settings.resp_rate)
 
-    def incrementMinuteVol(self):
+    def incrementMinuteVol(self) -> None:
         self.local_settings.minute_volume += self.settings.minute_volume_increment
         self.minute_vol_page_rect.updateValue(
             self.local_settings.minute_volume)
 
-    def decrementMinuteVol(self):
+    def decrementMinuteVol(self) -> None:
         self.local_settings.minute_volume -= self.settings.minute_volume_increment
         self.minute_vol_page_rect.updateValue(
             self.local_settings.minute_volume)
 
-    def changeIERatio(self, new_val):
+    def changeIERatio(self, new_val: int) -> None:
         self.local_settings.ie_ratio_id = new_val
         self.ie_page_rect.updateValue(self.local_settings.get_ie_display())
 
@@ -487,7 +224,7 @@ class MainWindow(QWidget):
         self.mode_button_main.updateValue(self.settings.get_mode_display())
         self.stack.setCurrentIndex(0)
 
-    def commitRespRate(self):
+    def commitRespRate(self) -> None:
         self.logChange(
             Change(
                 datetime.datetime.now(),
@@ -499,7 +236,7 @@ class MainWindow(QWidget):
         self.resp_rate_button_main.updateValue(self.settings.resp_rate)
         self.stack.setCurrentIndex(0)
 
-    def commitMinuteVol(self):
+    def commitMinuteVol(self) -> None:
         self.logChange(
             Change(
                 datetime.datetime.now(),
@@ -511,7 +248,7 @@ class MainWindow(QWidget):
         self.minute_vol_button_main.updateValue(self.settings.minute_volume)
         self.stack.setCurrentIndex(0)
 
-    def commitIERatio(self):
+    def commitIERatio(self) -> None:
         self.logChange(
             Change(
                 datetime.datetime.now(),
@@ -523,24 +260,23 @@ class MainWindow(QWidget):
         self.ie_button_main.updateValue(self.settings.get_ie_display())
         self.stack.setCurrentIndex(0)
 
-    def cancelChange(self):
+    def cancelChange(self) -> None:
         self.local_settings = deepcopy(self.settings)
         self.updateMainDisplays()
         self.stack.setCurrentIndex(0)
         self.updatePageDisplays()
 
-    def passChanges(self, param, new_val):
+    def passChanges(self, param, new_val) -> None:
         pass
         # TODO: pass settings to the Arduino
 
-    # change is a Change object
-    def logChange(self, change):
+    def logChange(self, change: Change) -> None:
         if change.old_val != change.new_val:
             print(change.display())
         # TODO: Actually log the change in some data structure
 
 
-def main(port, argv):
+def main(port, argv) -> None:
     app = QApplication(argv)
     window = MainWindow()
 


### PR DESCRIPTION
Hey guys,

So far the files we have been using one large file for creating the UI. I split it up by creating generic-ish functions within the `display/widgets.py` files that can be called and passed `self`. Since python passes objects by reference, it modifies the original object as long as the object is not overwritten by a new assignment. This should help us also modularize each section of the UI better and cut down the size of our `main` considerably.

Regards,

Zahi