### PR TITLE
Add alarms with simulation.  Connect alarms to UI callback.

### DIFF
--- a/ovve_ui/ovve_ui.py
+++ b/ovve_ui/ovve_ui.py
@@ -30,6 +30,7 @@ from display.widgets import (initializeHomeScreenWidget,
                              initializeIERatioWidget)
 from utils.params import Params
 from utils.settings import Settings
+from utils.alarms import Alarms
 from utils.comms_adapter import CommsAdapter
 from utils.comms_simulator import CommsSimulator
 
@@ -78,7 +79,11 @@ class MainWindow(QWidget):
 
         # Set a callback in the adapter that is called whenever new
         # params arrive from the comms handler
-        self.comms_adapter.set_ui_callback(self.update_ui)
+        self.comms_adapter.set_ui_params_callback(self.update_ui_params)
+
+        # Set a callback in the adapter that is called whenever new
+        # params arrive from the comms handler
+        self.comms_adapter.set_ui_alarms_callback(self.update_ui_alarms)
 
         # Set the adapter function that is called whenever settings are
         # udpated in the UI
@@ -158,11 +163,16 @@ class MainWindow(QWidget):
     def display(self, i: int) -> None:
         self.stack.setCurrentIndex(i)
 
-    def update_ui(self, params: Params) -> None:
+    def update_ui_params(self, params: Params) -> None:
         self.params = params
         self.updateMainDisplays()
         self.updateGraphs()
         self.updatePageDisplays()
+    
+    def update_ui_alarms(self, alarms: Alarms) -> None:
+        self.alarms = alarms
+        print("UI received alarms from comms adapter")
+        #TODO: Implement UI alarm handling
 
     def updateMainDisplays(self) -> None:
         self.mode_button_main.updateValue(self.get_mode_display(self.settings.mode))

--- a/ovve_ui/utils/alarms.py
+++ b/ovve_ui/utils/alarms.py
@@ -1,0 +1,51 @@
+"""
+Read-only alarms from the MCU
+"""
+import json
+from typing import Union
+from copy import deepcopy
+
+class Alarms():
+    """
+    Params defined in serialpacketv0.26.pptx
+    """
+    def __init__(self) -> None:
+        self._alarms: dict = {
+            "power_loss": False,
+            "low_battery": False,
+            "loss_of_breathing_circuit_integrity": False,
+            "high_airway_pressure": False,
+            "low_airway_pressure": False,
+            "low_delivered_tidal_volume": False,
+            "apnea": False,
+            "crc_error": False,
+            "dropped_packet": False,
+            "serial_comm_error": False,
+            "packet_version_unsupported": False,
+            "mode_value_mismatch": False,
+            "respiratory_rate_setpoint_mismatch": False,
+            "tidal_volume_value_mismatch": False,
+            "ie_ratio_mismatch": False,
+        }
+        
+    
+    def to_JSON(self) -> str:
+        """ Convert OVVE UI Params to JSON file """
+        return json.dumps(self._alarms)
+
+    def to_dict(self) -> dict:
+        """ Make a copy of the alarms dict """
+        return deepcopy(self._alarms)
+
+    def from_dict(self, input_dict: dict) -> None:
+        """ Set OVVE UI alarms from input dictionary """
+        for key in input_dict:
+            # Check if key from input_dict exists in ours
+            if key in self._alarms:
+                self._alarms[key] = input_dict[key]
+            else:
+                print("ALARM WAS SET WITH UNKNOWN KEY! " + key)
+
+    def from_JSON(self, j_str: str) -> None:
+        j = json.loads(j_str)
+        self.from_dict(j)

--- a/ovve_ui/utils/comms_adapter.py
+++ b/ovve_ui/utils/comms_adapter.py
@@ -6,17 +6,24 @@ from typing import Callable
 
 from utils.params import Params
 from utils.settings import Settings
+from utils.alarms import Alarms
 
 
 class CommsAdapter():
     def __init__(self) -> None:
-        self.ui_callback = None
+        self.ui_params_callback = None
+        self.ui_alarms_callback = None
         self.comms_callback = None
 
     # Sets the function in the UI that gets called whenever
     # params are updated.
-    def set_ui_callback(self, ui_callback: Callable[[Params], None]) -> None:
-        self.ui_callback = ui_callback
+    def set_ui_params_callback(self, ui_params_callback: Callable[[Params], None]) -> None:
+        self.ui_params_callback = ui_params_callback
+
+    # Sets the function in the UI that gets called whenever
+    # alarms are updated.
+    def set_ui_alarms_callback(self, ui_alarms_callback: Callable[[Alarms], None]) -> None:
+        self.ui_alarms_callback = ui_alarms_callback
 
     # Sets the function in the comms handler that gets called
     # whenever settings are updated
@@ -45,7 +52,23 @@ class CommsAdapter():
         print(params.to_JSON())
 
         # Call the callback provided by the UI
-        if self.ui_callback:
-            self.ui_callback(params)
+        if self.ui_params_callback:
+            self.ui_params_callback(params)
         else:
-            print("No UI callback!")
+            print("No UI params callback!")
+
+
+    def update_alarms(self, alarms_from_comms: dict) -> None:
+        alarms = Alarms()
+        alarms.from_dict(alarms_from_comms)
+
+        # Deserialize or otherwise handle params
+        # coming in from the comms handler
+        print("Got updated alarms from comms")
+        print(alarms.to_JSON())
+
+        # Call the callback provided by the UI
+        if self.ui_alarms_callback:
+            self.ui_alarms_callback(alarms)
+        else:
+            print("No UI alarms callback!")


### PR DESCRIPTION
Because multiple alarms can be set at one time, I implemented them as a dict of bools instead of individual properties.   That way you can easily iterate through them and see which ones are set.

I added alarms to the simulator.  They will fire every N seconds, and you will get a different alarm each time.  You could easily make them fire randomly with random values.