### PR TITLE
Adding ranges and defaults

### DIFF
--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -398,8 +398,7 @@ def initializeTidalVolumeWidget(window: MainWindow):
     tv_title_label.setAlignment(Qt.AlignCenter)
     tv_title_label.setStyleSheet("QLabel {color: #000000 ;}")
 
-
-    window.tv_page_value_label = QLabel(str(window.local_settings.resp_rate))
+    window.tv_page_value_label = QLabel(str(window.local_settings.tv))
     window.tv_page_value_label.setFont(page_settings.valueFont)
     window.tv_page_value_label.setStyleSheet("QLabel {color: " +
                                              page_settings.valueColor + ";}")
@@ -412,7 +411,7 @@ def initializeTidalVolumeWidget(window: MainWindow):
                                 ";}")
     tv_unit_label.setAlignment(Qt.AlignCenter)
 
-    tv_decrement_button = window.makeSimpleDisplayButton(
+    window.tv_decrement_button = window.makeSimpleDisplayButton(
         "-",
         size=(50, 50),
         button_settings=SimpleButtonSettings(
@@ -421,7 +420,15 @@ def initializeTidalVolumeWidget(window: MainWindow):
             valueSetting=page_settings.changeButtonTextSetting,
             valueColor=page_settings.changeButtonValueColor))
 
-    tv_increment_button = window.makeSimpleDisplayButton(
+    tv_decrement_size_policy = window.tv_decrement_button.sizePolicy()
+    tv_decrement_size_policy.setRetainSizeWhenHidden(True)
+    window.tv_decrement_button.setSizePolicy(tv_decrement_size_policy)
+
+    if window.local_settings.tv - window.ranges._ranges["tv_increment"] \
+            < window.ranges._ranges["min_tv"]:
+        window.tv_decrement_button.hide()
+
+    window.tv_increment_button = window.makeSimpleDisplayButton(
         "+",
         size=(50, 50),
         button_settings=SimpleButtonSettings(
@@ -429,6 +436,14 @@ def initializeTidalVolumeWidget(window: MainWindow):
             borderColor=page_settings.changeButtonBorderColor,
             valueSetting=page_settings.changeButtonTextSetting,
             valueColor=page_settings.changeButtonValueColor))
+
+    tv_increment_size_policy = window.tv_increment_button.sizePolicy()
+    tv_increment_size_policy.setRetainSizeWhenHidden(True)
+    window.tv_increment_button.setSizePolicy(tv_increment_size_policy)
+
+    if window.local_settings.tv + window.ranges._ranges["tv_increment"] \
+            > window.ranges._ranges["max_tv"]:
+        window.tv_increment_button.hide()
 
     tv_apply = window.makeSimpleDisplayButton(
         "APPLY",
@@ -445,15 +460,15 @@ def initializeTidalVolumeWidget(window: MainWindow):
             valueSetting=page_settings.cancelSetting,
             valueColor=page_settings.cancelColor))
 
-    tv_decrement_button.clicked.connect(window.decrementTidalVol)
-    tv_increment_button.clicked.connect(window.incrementTidalVol)
+    window.tv_decrement_button.clicked.connect(window.decrementTidalVol)
+    window.tv_increment_button.clicked.connect(window.incrementTidalVol)
     tv_apply.clicked.connect(window.commitTidalVol)
     tv_cancel.clicked.connect(window.cancelChange)
 
     h_box_1.addWidget(tv_title_label)
-    h_box_2.addWidget(tv_decrement_button)
+    h_box_2.addWidget(window.tv_decrement_button)
     h_box_2.addWidget(window.tv_page_value_label)
-    h_box_2.addWidget(tv_increment_button)
+    h_box_2.addWidget(window.tv_increment_button)
 
     h_box_3.addWidget(tv_unit_label)
     h_box_4.addWidget(tv_apply)

--- a/ovve_ui/display/widgets.py
+++ b/ovve_ui/display/widgets.py
@@ -301,7 +301,7 @@ def initializeRespiratoryRateWidget(window) -> None:
                                        page_settings.unitColor + ";}")
     resp_rate_unit_label.setAlignment(Qt.AlignCenter)
 
-    resp_rate_decrement_button = window.makeSimpleDisplayButton(
+    window.resp_rate_decrement_button = window.makeSimpleDisplayButton(
         "-",
         size=(50, 50),
         button_settings=SimpleButtonSettings(
@@ -310,7 +310,15 @@ def initializeRespiratoryRateWidget(window) -> None:
             valueSetting=page_settings.changeButtonTextSetting,
             valueColor=page_settings.changeButtonValueColor))
 
-    resp_rate_increment_button = window.makeSimpleDisplayButton(
+    resp_rate_decrement_size_policy = window.resp_rate_decrement_button.sizePolicy()
+    resp_rate_decrement_size_policy.setRetainSizeWhenHidden(True)
+    window.resp_rate_decrement_button.setSizePolicy(resp_rate_decrement_size_policy)
+
+    if window.local_settings.resp_rate - window.ranges._ranges["resp_rate_increment"] \
+            < window.ranges._ranges["min_resp_rate"]:
+        window.resp_rate_decrement_button.hide()
+
+    window.resp_rate_increment_button = window.makeSimpleDisplayButton(
         "+",
         size=(50, 50),
         button_settings=SimpleButtonSettings(
@@ -319,6 +327,14 @@ def initializeRespiratoryRateWidget(window) -> None:
             valueSetting=page_settings.changeButtonTextSetting,
             valueColor=page_settings.changeButtonValueColor))
 
+    resp_rate_increment_size_policy = window.resp_rate_increment_button.sizePolicy()
+    resp_rate_increment_size_policy.setRetainSizeWhenHidden(True)
+    window.resp_rate_increment_button.setSizePolicy(resp_rate_increment_size_policy)
+
+    if window.local_settings.resp_rate + window.ranges._ranges["resp_rate_increment"] \
+            > window.ranges._ranges["max_resp_rate"]:
+        window.resp_rate_increment_button.hide()
+
     resp_rate_apply = window.makeSimpleDisplayButton(
         "APPLY",
         button_settings=SimpleButtonSettings(
@@ -326,6 +342,7 @@ def initializeRespiratoryRateWidget(window) -> None:
             borderColor=page_settings.commitColor,
             valueSetting=page_settings.commitSetting,
             valueColor=page_settings.commitColor))
+
     resp_rate_cancel = window.makeSimpleDisplayButton(
         "CANCEL",
         button_settings=SimpleButtonSettings(
@@ -334,17 +351,18 @@ def initializeRespiratoryRateWidget(window) -> None:
             valueSetting=page_settings.cancelSetting,
             valueColor=page_settings.cancelColor))
 
-    resp_rate_decrement_button.clicked.connect(window.decrementRespRate)
-    resp_rate_increment_button.clicked.connect(window.incrementRespRate)
+    window.resp_rate_decrement_button.clicked.connect(window.decrementRespRate)
+    window.resp_rate_increment_button.clicked.connect(window.incrementRespRate)
+
     resp_rate_apply.clicked.connect(window.commitRespRate)
     resp_rate_cancel.clicked.connect(window.cancelChange)
 
     h_box_1.addWidget(resp_rate_title_label)
-    h_box_2.addWidget(resp_rate_decrement_button)
+    h_box_2.addWidget(window.resp_rate_decrement_button)
     h_box_2.addWidget(window.resp_rate_page_value_label)
     window.resp_rate_page_value_label.setFixedWidth(
         page_settings.valueLabelWidth)
-    h_box_2.addWidget(resp_rate_increment_button)
+    h_box_2.addWidget( window.resp_rate_increment_button)
     h_box_3.addWidget(resp_rate_unit_label)
     h_box_4.addWidget(resp_rate_apply)
     h_box_4.addWidget(resp_rate_cancel)
@@ -353,6 +371,8 @@ def initializeRespiratoryRateWidget(window) -> None:
     v_box.addLayout(h_box_2)
     v_box.addLayout(h_box_3)
     v_box.addLayout(h_box_4)
+
+
 
     window.page["3"].setLayout(v_box)
 

--- a/ovve_ui/ovve_ui.py
+++ b/ovve_ui/ovve_ui.py
@@ -33,7 +33,7 @@ from utils.alarms import Alarms
 from utils.comms_simulator import CommsSimulator
 from utils.comms_link import CommsLink
 from utils.logger import Logger
-
+from utils.ranges import Ranges
 
 class MainWindow(QWidget):
     new_settings_signal = pyqtSignal(dict)
@@ -43,15 +43,13 @@ class MainWindow(QWidget):
         self.settings = Settings()
         self.local_settings = Settings()  # local settings are changed with UI
         self.params = Params()
+        self.ranges = Ranges()
         
         
         self.fullscreen = False
 
         # you can pass new settings for different object classes here
         self.ui_settings = UISettings()
-
-        self.resp_rate_increment = 1
-        self.tv_increment = 25
 
         # Example 1 (changes color of Fancy numbers to red)
         # self.ui_settings.set_fancy_button_settings(FancyButtonSettings(valueColor=Qt.red))
@@ -248,21 +246,30 @@ class MainWindow(QWidget):
             self.get_mode_display(self.local_settings.mode))
 
     def incrementRespRate(self) -> None:
-        self.local_settings.resp_rate += self.resp_rate_increment
+        self.local_settings.resp_rate += self.ranges._ranges["resp_rate_increment"]
         self.resp_rate_page_value_label.setText(
             str(self.local_settings.resp_rate))
+        if self.local_settings.resp_rate + self.ranges._ranges["resp_rate_increment"] \
+            > self.ranges._ranges["max_resp_rate"]:
+            self.resp_rate_increment_button.hide()
+        self.resp_rate_decrement_button.show()
+
 
     def decrementRespRate(self) -> None:
-        self.local_settings.resp_rate -= self.resp_rate_increment
+        self.local_settings.resp_rate -= self.ranges._ranges["resp_rate_increment"]
         self.resp_rate_page_value_label.setText(
             str(self.local_settings.resp_rate))
+        if self.local_settings.resp_rate - self.ranges._ranges["resp_rate_increment"] \
+            < self.ranges._ranges["min_resp_rate"]:
+            self.resp_rate_decrement_button.hide()
+        self.resp_rate_increment_button.show()
 
     def incrementTidalVol(self) -> None:
-        self.local_settings.tv += self.tv_increment
+        self.local_settings.tv += self.ranges._ranges["tv_increment"]
         self.tv_page_value_label.setText(str(self.local_settings.tv))
 
     def decrementTidalVol(self) -> None:
-        self.local_settings.tv -= self.tv_increment
+        self.local_settings.tv -= self.ranges._ranges["tv_increment"]
         self.tv_page_value_label.setText(str(self.local_settings.tv))
 
     def incrementIERatio(self) -> None:

--- a/ovve_ui/ovve_ui.py
+++ b/ovve_ui/ovve_ui.py
@@ -267,10 +267,18 @@ class MainWindow(QWidget):
     def incrementTidalVol(self) -> None:
         self.local_settings.tv += self.ranges._ranges["tv_increment"]
         self.tv_page_value_label.setText(str(self.local_settings.tv))
+        if self.local_settings.tv + self.ranges._ranges["tv_increment"] \
+            > self.ranges._ranges["max_tv"]:
+            self.tv_increment_button.hide()
+        self.tv_decrement_button.show()
 
     def decrementTidalVol(self) -> None:
         self.local_settings.tv -= self.ranges._ranges["tv_increment"]
         self.tv_page_value_label.setText(str(self.local_settings.tv))
+        if self.local_settings.tv - self.ranges._ranges["tv_increment"] \
+            < self.ranges._ranges["min_tv"]:
+            self.tv_decrement_button.hide()
+        self.tv_increment_button.show()
 
     def incrementIERatio(self) -> None:
         self.local_settings.ie_ratio += 1

--- a/ovve_ui/utils/ranges.py
+++ b/ovve_ui/utils/ranges.py
@@ -1,0 +1,38 @@
+"""
+Settings that are sent to MCU
+"""
+import json
+from typing import List
+from copy import deepcopy
+
+class Ranges():
+    def __init__(self) -> None:
+        self._ranges: dict = {
+            "min_resp_rate": 5, #Unit: bpm
+            "max_resp_rate": 35,
+            "resp_rate_increment": 1,
+            "tv_min": 150, #Unit: mL
+            "tv_max": 800,
+            "tv_increment": 25
+        }
+
+    def to_JSON(self) -> str:
+        """ Convert OVVE UI Params to JSON file """
+        return json.dumps(self._alarms)
+
+    def to_dict(self) -> dict:
+        """ Make a copy of the alarms dict """
+        return deepcopy(self._alarms)
+
+    def from_dict(self, input_dict: dict) -> None:
+        """ Set OVVE UI alarms from input dictionary """
+        for key in input_dict:
+            # Check if key from input_dict exists in ours
+            if key in self._ranges:
+                self._ranges[key] = input_dict[key]
+            else:
+                print("RANGE WAS SET WITH UNKNOWN KEY! " + key)
+
+    def from_JSON(self, j_str: str) -> None:
+        j = json.loads(j_str)
+        self.from_dict(j)

--- a/ovve_ui/utils/ranges.py
+++ b/ovve_ui/utils/ranges.py
@@ -11,8 +11,8 @@ class Ranges():
             "min_resp_rate": 5, #Unit: bpm
             "max_resp_rate": 35,
             "resp_rate_increment": 1,
-            "tv_min": 150, #Unit: mL
-            "tv_max": 800,
+            "min_tv": 150, #Unit: mL
+            "max_tv": 800,
             "tv_increment": 25
         }
 

--- a/ovve_ui/utils/settings.py
+++ b/ovve_ui/utils/settings.py
@@ -15,8 +15,8 @@ class Settings():
             1: "SIMV",
         }
 
-        self.resp_rate: int = 0
-        self.tv: int = 0
+        self.resp_rate: int = 20
+        self.tv: int = 475
         self.ie_ratio: int = 0
 
         self.ie_ratio_switcher: dict = {


### PR DESCRIPTION
Added ranges for tidal volume and resp. rate
System now automatically hides increment and decrement buttons for tidal vol. and resp. rate if incrementing/decrementing would cause a value outside the acceptable range