### PR TITLE
Fix issues with startbit - Using LSB 0 bit numbering

### DIFF
--- a/ovve_ui/utils/in_packet.py
+++ b/ovve_ui/utils/in_packet.py
@@ -88,10 +88,6 @@ class InPacket():
         # VC_CMV_ASSISTED_OFF = 129
         # SIMV_OFF = 3
         # SIMV_ON = 130
-        
-        if mode_value & ( 1 << 7):
-            startBit = 1
-        else:
-            startBit = 0
+        # get MSB but 7
 
-        return startBit
+        return mode_value & ( 1 << 7)

--- a/ovve_ui/utils/in_packet.py
+++ b/ovve_ui/utils/in_packet.py
@@ -83,38 +83,15 @@ class InPacket():
 
     def calculate_runstate(self, mode_value):
         # VC_CMV_NON_ASSISTED_OFF = 0
-        # VC_CMV_NON_ASSISTED_ON = 1
+        # VC_CMV_NON_ASSISTED_ON = 128
         # VC_CMV_ASSISTED_OFF = 2
-        # VC_CMV_ASSISTED_OFF = 3
-        # SIMV_OFF = 4
-        # SIMV_ON = 5
+        # VC_CMV_ASSISTED_OFF = 129
+        # SIMV_OFF = 3
+        # SIMV_ON = 130
         
-        startBit = None
-
-        # if mode_value == 0:
-        #     startBit = 0
-        # elif mode_value == 1:
-        #     startBit = 1
-        # elif mode_value == 2:
-        #     startBit = 0
-        # elif mode_value == 3:
-        #     startBit == 1
-        # elif mode_value == 4:
-        #     startBit == 0
-        # elif mode_value == 5:
-        #     startBit = 1
-        if mode_value == 0:
-                startBit = 0
-        elif mode_value == 128:
-            startBit = 1
-        elif mode_value == 1:
-            startBit = 0
-        elif mode_value == 129:
-            startBit == 1
-        elif mode_value == 2:
-            startBit == 0
-        elif mode_value == 130:
+        if mode_value & ( 1 << 7):
             startBit = 1
         else:
             startBit = 0
+
         return startBit

--- a/ovve_ui/utils/in_packet.py
+++ b/ovve_ui/utils/in_packet.py
@@ -91,17 +91,29 @@ class InPacket():
         
         startBit = None
 
+        # if mode_value == 0:
+        #     startBit = 0
+        # elif mode_value == 1:
+        #     startBit = 1
+        # elif mode_value == 2:
+        #     startBit = 0
+        # elif mode_value == 3:
+        #     startBit == 1
+        # elif mode_value == 4:
+        #     startBit == 0
+        # elif mode_value == 5:
+        #     startBit = 1
         if mode_value == 0:
-            startBit = 0
-        elif mode_value == 1:
+                startBit = 0
+        elif mode_value == 128:
             startBit = 1
-        elif mode_value == 2:
+        elif mode_value == 1:
             startBit = 0
-        elif mode_value == 3:
+        elif mode_value == 129:
             startBit == 1
-        elif mode_value == 4:
+        elif mode_value == 2:
             startBit == 0
-        elif mode_value == 5:
+        elif mode_value == 130:
             startBit = 1
         else:
             startBit = 0

--- a/ovve_ui/utils/out_packet.py
+++ b/ovve_ui/utils/out_packet.py
@@ -52,21 +52,21 @@ class OutPacket():
         mode = 0
         # get the updates from settings 
         # Set the mode value byte which also includes start bit
-        # self.cmd_pkt['mode_value'] = (self.settings.mode & 0x7f) | ((self.settings.run_state << 7) & 0x80)
-        # mode = (in_mode & 0x7f) | ((run_state << 7) & 0x80)
-        if in_mode == 0 and run_state == 0:
-            return 0
-        elif in_mode == 0 and run_state == 1:
-            mode =  128
-        elif in_mode == 1 and run_state == 0:
-            mode =  1
-        elif in_mode == 1 and run_state == 1:
-            mode = 129
-        elif in_mode == 2 and run_state == 0:
-            mode = 2
-        elif in_mode == 2 and run_state == 1:
-            mode = 130
-        else:
-            mode = 0
+
+        mode = in_mode & 0x7f | (run_state << 7) & 0x80
+        # if in_mode == 0 and run_state == 0:
+        #     return 0
+        # elif in_mode == 0 and run_state == 1:
+        #     mode =  128
+        # elif in_mode == 1 and run_state == 0:
+        #     mode =  1
+        # elif in_mode == 1 and run_state == 1:
+        #     mode = 129
+        # elif in_mode == 2 and run_state == 0:
+        #     mode = 2
+        # elif in_mode == 2 and run_state == 1:
+        #     mode = 130
+        # else:
+        #     mode = 0
         
         return mode

--- a/ovve_ui/utils/out_packet.py
+++ b/ovve_ui/utils/out_packet.py
@@ -52,17 +52,21 @@ class OutPacket():
         mode = 0
         # get the updates from settings 
         # Set the mode value byte which also includes start bit
+        # self.cmd_pkt['mode_value'] = (self.settings.mode & 0x7f) | ((self.settings.run_state << 7) & 0x80)
+        # mode = (in_mode & 0x7f) | ((run_state << 7) & 0x80)
         if in_mode == 0 and run_state == 0:
             return 0
         elif in_mode == 0 and run_state == 1:
-            mode =  1
+            mode =  128
         elif in_mode == 1 and run_state == 0:
-            mode =  2
+            mode =  1
         elif in_mode == 1 and run_state == 1:
-            mode = 3
+            mode = 129
         elif in_mode == 2 and run_state == 0:
-            mode = 4
+            mode = 2
         elif in_mode == 2 and run_state == 1:
-            mode = 5
+            mode = 130
+        else:
+            mode = 0
         
         return mode

--- a/ovve_ui/utils/out_packet.py
+++ b/ovve_ui/utils/out_packet.py
@@ -43,30 +43,14 @@ class OutPacket():
         
     def calculate_mode(self, in_mode, run_state) -> int:
          # VC_CMV_NON_ASSISTED_OFF = 0
-        # VC_CMV_NON_ASSISTED_ON = 1
-        # VC_CMV_ASSISTED_OFF = 2
-        # VC_CMV_ASSISTED_OFF = 3
-        # SIMV_OFF = 4
-        # SIMV_ON = 5
-
-        mode = 0
+        # VC_CMV_NON_ASSISTED_ON = 128
+        # VC_CMV_ASSISTED_OFF = 1
+        # VC_CMV_ASSISTED_OFF = 129
+        # SIMV_OFF = 3
+        # SIMV_ON = 130
         # get the updates from settings 
         # Set the mode value byte which also includes start bit
+    
 
-        mode = in_mode & 0x7f | (run_state << 7) & 0x80
-        # if in_mode == 0 and run_state == 0:
-        #     return 0
-        # elif in_mode == 0 and run_state == 1:
-        #     mode =  128
-        # elif in_mode == 1 and run_state == 0:
-        #     mode =  1
-        # elif in_mode == 1 and run_state == 1:
-        #     mode = 129
-        # elif in_mode == 2 and run_state == 0:
-        #     mode = 2
-        # elif in_mode == 2 and run_state == 1:
-        #     mode = 130
-        # else:
-        #     mode = 0
-        
-        return mode
+        return  (in_mode & 0x7f | (run_state << 7) & 0x80)
+


### PR DESCRIPTION
I tested this using @russmcinnis    debug statement in the controller serial branch and I verified that the mode value and start bit value change accordingly by changing the modes and start stop in the UI. I had to use byte values rather than using bit shift as @mrrosen suggested.